### PR TITLE
refactor: remove redundant computation

### DIFF
--- a/src/rust/integer_compression/fastpfor.rs
+++ b/src/rust/integer_compression/fastpfor.rs
@@ -29,10 +29,11 @@ impl Skippable for FastPFOR {
         output: &mut [u32],
         output_offset: &mut Cursor<u32>,
     ) -> FastPForResult<()> {
+        let inlength = helpers::greatest_multiple(input_length, self.block_size);
         let pos = input_offset.position() as u32;
-        let final_inpos = pos + input_length;
-        let this_size = std::cmp::min(self.page_size, final_inpos - pos);
+        let final_inpos = pos + inlength;
         while input_offset.position() as u32 != final_inpos {
+            let this_size = std::cmp::min(self.page_size, final_inpos - pos);
             self.encode_page(input, this_size, input_offset, output, output_offset);
         }
         FastPForResult::Ok(())

--- a/src/rust/integer_compression/fastpfor.rs
+++ b/src/rust/integer_compression/fastpfor.rs
@@ -32,10 +32,8 @@ impl Skippable for FastPFOR {
         let inlength = helpers::greatest_multiple(input_length, self.block_size);
         let final_inpos = input_offset.position() as u32 + inlength;
         while input_offset.position() as u32 != final_inpos {
-            let this_size = std::cmp::min(
-                self.page_size,
-                final_inpos - input_offset.position() as u32,
-            );
+            let this_size =
+                std::cmp::min(self.page_size, final_inpos - input_offset.position() as u32);
             self.encode_page(input, this_size, input_offset, output, output_offset);
         }
         FastPForResult::Ok(())

--- a/src/rust/integer_compression/fastpfor.rs
+++ b/src/rust/integer_compression/fastpfor.rs
@@ -30,10 +30,12 @@ impl Skippable for FastPFOR {
         output_offset: &mut Cursor<u32>,
     ) -> FastPForResult<()> {
         let inlength = helpers::greatest_multiple(input_length, self.block_size);
-        let pos = input_offset.position() as u32;
-        let final_inpos = pos + inlength;
+        let final_inpos = input_offset.position() as u32 + inlength;
         while input_offset.position() as u32 != final_inpos {
-            let this_size = std::cmp::min(self.page_size, final_inpos - pos);
+            let this_size = std::cmp::min(
+                self.page_size,
+                final_inpos - input_offset.position() as u32,
+            );
             self.encode_page(input, this_size, input_offset, output, output_offset);
         }
         FastPForResult::Ok(())

--- a/src/rust/integer_compression/fastpfor.rs
+++ b/src/rust/integer_compression/fastpfor.rs
@@ -29,11 +29,10 @@ impl Skippable for FastPFOR {
         output: &mut [u32],
         output_offset: &mut Cursor<u32>,
     ) -> FastPForResult<()> {
-        let inlength = helpers::greatest_multiple(input_length, self.block_size);
         let pos = input_offset.position() as u32;
-        let final_inpos = pos + inlength;
+        let final_inpos = pos + input_length;
+        let this_size = std::cmp::min(self.page_size, final_inpos - pos);
         while input_offset.position() as u32 != final_inpos {
-            let this_size = std::cmp::min(self.page_size, final_inpos - pos);
             self.encode_page(input, this_size, input_offset, output, output_offset);
         }
         FastPForResult::Ok(())

--- a/tests/basic_tests.rs
+++ b/tests/basic_tests.rs
@@ -380,15 +380,15 @@ fn test_random_numbers() {
 #[test]
 fn test_fastpfor_headless_compress_unfit_pagesize() {
     // The input size is a multiple of 128 but does not fit the page size
-    let test_input_size = 512+BLOCK_SIZE_128;
+    let test_input_size = 512 + BLOCK_SIZE_128;
     let page_size = 512;
 
     let input: Vec<u32> = (0..test_input_size).collect();
-    let mut output: Vec<u32> = vec![0; input.len()]; 
+    let mut output: Vec<u32> = vec![0; input.len()];
     let mut decoded: Vec<u32> = vec![0; input.len()];
     let mut input_offset = Cursor::new(0u32);
     let mut output_offset = Cursor::new(0u32);
-    
+
     let mut codec = FastPFOR::new(page_size, BLOCK_SIZE_128);
     codec
         .compress(
@@ -413,5 +413,5 @@ fn test_fastpfor_headless_compress_unfit_pagesize() {
         )
         .expect("decompression failed");
 
-    assert_eq!(input, decoded, "Input and decompressed data do not match"); 
+    assert_eq!(input, decoded, "Input and decompressed data do not match");
 }


### PR DESCRIPTION
Context:
- Fixes a bug in headless_compress where this_size was not updated dynamically per iteration. 

Implemented:
- Made `this_size` be updated per iteration
- A unit test to ensure compression correctly handles inputs that do not fit exactly into page sizes.