### PR TITLE
test: rust decoding test for cpp-encoded result

### DIFF
--- a/tests/cpp_compat_tests.rs
+++ b/tests/cpp_compat_tests.rs
@@ -1,33 +1,33 @@
-#![cfg(feature = "rust")]
+#![cfg(all(feature = "rust", feature = "cpp"))]
 
-use fastpfor::cpp::{Codec32, FastPFor128Codec};
-use fastpfor::rust::{FastPFOR, Integer, BLOCK_SIZE_128, DEFAULT_PAGE_SIZE};
+use fastpfor::cpp::Codec32;
+use fastpfor::rust::Integer;
+use fastpfor::{cpp, rust};
 use std::io::Cursor;
 
 #[test]
 fn test_rust_decompresses_cpp_encoded_data() {
-    let test_input_size = 256;
-    let input: Vec<u32> = (0..test_input_size).map(|i| (i * 32) ^ (i >> 1)).collect();
+    let input: Vec<u32> = (0..256).map(|i| (i * 32) ^ (i >> 1)).collect();
 
     // Buffer for the C++ encoded
     let mut compressed_buffer = vec![0; input.len()];
 
     // C++ encoding
-    let codec_cpp = FastPFor128Codec::new();
+    let codec_cpp = cpp::FastPFor128Codec::new();
     let encoded_cpp = codec_cpp
         .encode32(&input, &mut compressed_buffer)
-        .expect("C++ compression failed");
+        .unwrap();
     let compressed_len = encoded_cpp.len();
 
     // C++ decoding
     let mut decoded_by_cpp = vec![0; input.len()];
     let decoded_cpp = codec_cpp
         .decode32(encoded_cpp, &mut decoded_by_cpp)
-        .expect("C++ decompression failed");
+        .unwrap();
 
     // Rust decoding
     let mut input_offset = Cursor::new(0u32);
-    let mut codec_rs = FastPFOR::new(DEFAULT_PAGE_SIZE, BLOCK_SIZE_128);
+    let mut codec_rs = rust::FastPFOR::new(rust::DEFAULT_PAGE_SIZE, rust::BLOCK_SIZE_128);
     let mut decoded_by_rust = vec![0; input.len()];
     codec_rs
         .uncompress(
@@ -37,7 +37,7 @@ fn test_rust_decompresses_cpp_encoded_data() {
             &mut decoded_by_rust,
             &mut Cursor::new(0u32),
         )
-        .expect("Rust decompression failed");
+        .unwrap();
 
     assert_eq!(
         decoded_cpp.len(),

--- a/tests/cpp_compat_tests.rs
+++ b/tests/cpp_compat_tests.rs
@@ -8,7 +8,7 @@ use std::io::Cursor;
 fn test_rust_decompresses_cpp_encoded_data() {
     let test_input_size = 256;
     let input: Vec<u32> = (0..test_input_size).map(|i| (i * 32) ^ (i >> 1)).collect();
-    
+
     // Buffer for the C++ encoded
     let mut compressed_buffer = vec![0; input.len()];
 

--- a/tests/cpp_compat_tests.rs
+++ b/tests/cpp_compat_tests.rs
@@ -1,0 +1,48 @@
+#![cfg(feature = "rust")]
+
+use fastpfor::cpp::{Codec32, FastPFor128Codec};
+use fastpfor::rust::{FastPFOR, Integer, BLOCK_SIZE_128, DEFAULT_PAGE_SIZE};
+use std::io::Cursor;
+
+#[test]
+fn test_rust_decompresses_cpp_encoded_data() {
+    let test_input_size = 256;
+    let input: Vec<u32> = (0..test_input_size).map(|i| (i * 32) ^ (i >> 1)).collect();
+    
+    // Buffer for the C++ encoded
+    let mut compressed_buffer = vec![0; input.len()];
+
+    // C++ encoding
+    let codec_cpp = FastPFor128Codec::new();
+    let encoded_cpp = codec_cpp
+        .encode32(&input, &mut compressed_buffer)
+        .expect("C++ compression failed");
+    let compressed_len = encoded_cpp.len();
+
+    // C++ decoding
+    let mut decoded_by_cpp = vec![0; input.len()];
+    let decoded_cpp = codec_cpp
+        .decode32(encoded_cpp, &mut decoded_by_cpp)
+        .expect("C++ decompression failed");
+
+    // Rust decoding
+    let mut input_offset = Cursor::new(0u32);
+    let mut codec_rs = FastPFOR::new(DEFAULT_PAGE_SIZE, BLOCK_SIZE_128);
+    let mut decoded_by_rust = vec![0; input.len()];
+    codec_rs
+        .uncompress(
+            &compressed_buffer,
+            compressed_len as u32,
+            &mut input_offset,
+            &mut decoded_by_rust,
+            &mut Cursor::new(0u32),
+        )
+        .expect("Rust decompression failed");
+
+    assert_eq!(
+        decoded_cpp.len(),
+        decoded_by_rust.len(),
+        "Mismatched output lengths"
+    );
+    assert_eq!(decoded_cpp, decoded_by_rust);
+}

--- a/tests/cpp_compat_tests.rs
+++ b/tests/cpp_compat_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(all(feature = "rust", feature = "cpp"))]
 
-use fastpfor::cpp::Codec32;
-use fastpfor::rust::Integer;
+use fastpfor::cpp::Codec32 as _;
+use fastpfor::rust::Integer as _;
 use fastpfor::{cpp, rust};
 use std::io::Cursor;
 

--- a/tests/cpp_compat_tests.rs
+++ b/tests/cpp_compat_tests.rs
@@ -14,9 +14,7 @@ fn test_rust_decompresses_cpp_encoded_data() {
 
     // C++ encoding
     let codec_cpp = cpp::FastPFor128Codec::new();
-    let encoded_cpp = codec_cpp
-        .encode32(&input, &mut compressed_buffer)
-        .unwrap();
+    let encoded_cpp = codec_cpp.encode32(&input, &mut compressed_buffer).unwrap();
     let compressed_len = encoded_cpp.len();
 
     // C++ decoding


### PR DESCRIPTION
Context:
- As we develop the native Rust implementation, we need a way to ensure the results match those from the benchmark C++ implementation.

Implemented:
- Added `test_rust_decompresses_cpp_encoded_data` to verify end-to-end decoding using deterministic input with varied bit patterns for better coverage.