### PR TITLE
refactor: remove unnecessary spaces in exceptional value vector allocation

### DIFF
--- a/src/rust/integer_compression/fastpfor.rs
+++ b/src/rust/integer_compression/fastpfor.rs
@@ -120,14 +120,7 @@ impl FastPFOR {
             page_size,
             block_size,
             bytes_container: bytebuffer::ByteBuffer::new(3 * page_size / block_size + page_size),
-            data_to_be_packed: {
-                let mut data_to_be_packed: Vec<Vec<u32>> =
-                    vec![vec![0; page_size as usize / 32 * 4]; 33];
-                for _ in 1..data_to_be_packed.len() {
-                    data_to_be_packed.push(vec![0; page_size as usize / 32 * 4]);
-                }
-                data_to_be_packed
-            },
+            data_to_be_packed: vec![vec![0; page_size as usize / 32 * 4]; 33],
             data_pointers: vec![0; 33],
             freqs: vec![0; 33],
             bestbbestcexceptmaxb: [0; 3],


### PR DESCRIPTION
Implemented:
- Removed the allocation of 32 additional vectors, as only 33 vectors are needed.

Reference:
- C++: https://github.com/fast-pack/FastPFOR/blob/d20b2e3eac95c83377afbde6d092efd0fb255137/headers/fastpfor.h#L343C3-L346C61
- JAVA: https://github.com/fast-pack/JavaFastPFOR/blob/182c6d2147d1feb50fd2397f58e33735519d096f/src/main/java/me/lemire/integercompression/FastPFOR.java#L74C13-L76C10